### PR TITLE
Reorder Game List DESC & Several Bug Fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
 
   <head>
     <title>Softball App</title>
-    <link rel="shortcut icon" href="/favicon.ico" />
+    <link href="/favicon.ico" rel="icon" type="image/vnd.microsoft.icon">
     <link rel="manifest" href="/server/manifest" />
     <link rel="stylesheet" type="text/css" href="/server/assets/main.css" />
     <link
@@ -27,7 +27,7 @@
     />
     <meta
       property="og:image"
-      content="https://softball.app/assets/logo512.png"
+      content="https://softball.app/assets/logo512-alt2.png"
     />
     <meta property="og:type" content="product" />
     <meta property="fb:app_id" content="1646381242138657" />

--- a/src-srv/softball-server.js
+++ b/src-srv/softball-server.js
@@ -260,7 +260,10 @@ module.exports = class SoftballServer {
           }
           res.status(200).send(state);
         } else {
-          logger.warn(null, 'No account found with stat_page_id=' + publicId);
+          logger.warn(
+            null,
+            'No account found with stat_page_id=' + publicTeamId
+          );
           res.status(404).send();
         }
       })

--- a/src/actions/route.js
+++ b/src/actions/route.js
@@ -29,6 +29,10 @@ export function goBack() {
   }
 }
 
+export function goHome() {
+  setRoute('/');
+}
+
 export function setOnGoBack(cb) {
   onGoBack = cb;
 }

--- a/src/card-game-list.js
+++ b/src/card-game-list.js
@@ -1,9 +1,10 @@
 import React from 'react';
-import DOM from 'react-dom-factories';
 import state from 'state';
 import { setRoute } from 'actions/route';
+import { sortObjectsByDate } from 'utils/functions';
+import injectSheet from 'react-jss';
 
-export default class CardGameList extends React.Component {
+class CardGameList extends React.Component {
   constructor(props) {
     super(props);
     this.state = {};
@@ -12,9 +13,8 @@ export default class CardGameList extends React.Component {
       setRoute(`/teams/${props.team.id}/games/${game.id}`); // TODO: always back to lineup?
     };
 
-    this.handleEditClick = function(game, ev) {
+    this.handleEditClick = function(game) {
       setRoute(`/teams/${props.team.id}/games/${game.id}/edit`);
-      ev.stopPropagation();
     };
 
     this.handleCreateClick = function() {
@@ -24,53 +24,45 @@ export default class CardGameList extends React.Component {
   }
 
   renderGameList() {
-    const elems = this.props.team.games.map(game => {
-      return DOM.div(
-        {
-          game_id: game.id,
-          id: 'game-' + game.id,
-          key: 'game' + game.id,
-          className: 'list-item',
-          onClick: this.handleGameClick.bind(this, game),
-          style: {
-            display: 'flex',
-            justifyContent: 'space-between',
-          },
-        },
-        DOM.div(
-          {
-            className: 'prevent-overflow',
-          },
-          'Vs. ' + game.opponent
-        ),
-        DOM.div(
-          {
-            style: {},
-          },
-          DOM.img({
-            src: '/server/assets/edit.svg',
-            alt: 'edit',
-            className: 'list-button',
-            id: 'game-' + game.id + '-edit',
-            onClick: this.handleEditClick.bind(this, game),
-          })
-        )
+    const elems = sortObjectsByDate(this.props.team.games).map(game => {
+      return (
+        <div
+          key={'game-' + game.id}
+          id={'game-' + game.id}
+          className={'list-item ' + this.props.classes.listItem}
+          onClick={this.handleGameClick.bind(this, game)}
+        >
+          <img
+            src="/server/assets/edit.svg"
+            alt="edit"
+            className={'list-button ' + this.props.classes.listButton}
+            id={'game-' + game.id + '-edit'}
+            onClick={ev => {
+              this.handleEditClick(game);
+              ev.preventDefault();
+              ev.stopPropagation();
+            }}
+          />
+          <div className={this.props.classes.dateText}>
+            {new Date(game.date * 1000).toISOString().substring(0, 10)}
+          </div>
+          <div className="prevent-overflow">{'Vs. ' + game.opponent}</div>
+        </div>
       );
     });
 
-    elems.push(
-      DOM.div(
-        {
-          id: 'newGame',
-          key: 'newGame',
-          className: 'list-item add-list-item',
-          onClick: this.handleCreateClick,
-        },
-        '+ Add New Game'
-      )
+    elems.unshift(
+      <div
+        id="newGame"
+        key="newGame"
+        className={'list-item add-list-item ' + this.props.classes.listItem}
+        onClick={this.handleCreateClick}
+      >
+        + Add New Game
+      </div>
     );
 
-    return DOM.div({}, elems);
+    return <>{elems}</>;
   }
 
   render() {
@@ -81,3 +73,21 @@ export default class CardGameList extends React.Component {
     );
   }
 }
+
+export default injectSheet(theme => ({
+  listItem: {
+    lineHeight: '20px',
+    [`@media (max-width:${theme.breakpoints.sm})`]: {
+      fontSize: '14px',
+      lineHeight: '14px',
+    },
+  },
+  listButton: {
+    float: 'right',
+  },
+  dateText: {
+    float: 'right',
+    marginRight: '32px',
+    fontSize: '12px',
+  },
+}))(CardGameList);

--- a/src/card-plate-appearance.js
+++ b/src/card-plate-appearance.js
@@ -22,7 +22,20 @@ const styles = theme => ({
     margin: '4px',
   },
   button: {
-    cursor: 'pointer',
+    cursor: 'default',
+    padding: '12px',
+    color: theme.colors.TEXT_LIGHT,
+    border: `2px solid ${theme.colors.SECONDARY}`,
+    borderRadius: '4px',
+    textAlign: 'center',
+    fontSize: '18px',
+    width: '48px',
+    margin: '2px',
+    [`@media (max-width:${theme.breakpoints.sm})`]: {
+      fontSize: '16px',
+      padding: '6px',
+      margin: '0px',
+    },
   },
   buttonSelected: {
     backgroundColor: theme.colors.SECONDARY,
@@ -228,7 +241,7 @@ class CardPlateAppearance extends React.Component {
           id={'result-' + result}
           key={`${i} ${result}`}
           className={
-            'button result-button' +
+            this.props.classes.button +
             (this.state.paResult === result
               ? ' ' + this.props.classes.buttonSelected
               : '')

--- a/src/card-stats.js
+++ b/src/card-stats.js
@@ -204,16 +204,42 @@ export default class CardStats extends React.Component {
     );
   }
 
+  renderNoTable() {
+    if (this.props.routingMethod === 'app') {
+      return (
+        <CardSection isCentered={true}>
+          There aren't any stats for this team yet!
+        </CardSection>
+      );
+    } else {
+      return (
+        <Card title={`${this.props?.team?.name} Stats`}>
+          <div
+            style={{
+              color: css.colors.TEXT_LIGHT,
+              display: 'flex',
+              justifyContent: 'space-around',
+              marginTop: css.spacing.xSmall,
+            }}
+          >
+            <div> There aren't any stats for this team yet! </div>
+          </div>
+        </Card>
+      );
+    }
+  }
+
   render() {
     const { team, routingMethod, state: stateProps } = this.props;
-
-    if (!team) {
-      throw new Error('No team given to CardStats.');
-    }
 
     // TODO: Generate this once when the component mounts.  It's very redundant to do it
     // on each render
     const s = stateProps || state.getLocalState();
+
+    if (!team) {
+      return this.renderNoTable();
+    }
+
     const playerStatsList = s.players
       .filter(player => {
         return team.games.reduce((result, game) => {
@@ -228,7 +254,7 @@ export default class CardStats extends React.Component {
       });
 
     if (playerStatsList.length === 0) {
-      throw new Error('No playerStats could be generated.');
+      return this.renderNoTable();
     }
 
     const tableElems = [this.renderStatsHeader()].concat(

--- a/src/card-team-list.js
+++ b/src/card-team-list.js
@@ -3,8 +3,9 @@ import DOM from 'react-dom-factories';
 import state from 'state';
 import { setRoute } from 'actions/route';
 import Card from 'elements/card';
+import injectSheet from 'react-jss';
 
-export default class CardTeamList extends React.Component {
+class CardTeamList extends React.Component {
   constructor(props) {
     super(props);
     this.state = {};
@@ -31,7 +32,7 @@ export default class CardTeamList extends React.Component {
           id: 'team-' + team.id,
           team_id: team.id,
           key: 'team' + team.id,
-          className: 'list-item',
+          className: 'list-item ' + this.props.classes.listItem,
           onClick: this.handleTeamClick.bind(this, team),
           style: {
             display: 'flex',
@@ -59,12 +60,12 @@ export default class CardTeamList extends React.Component {
       );
     });
 
-    elems.push(
+    elems.unshift(
       DOM.div(
         {
           key: 'newTeam',
           id: 'newTeam',
-          className: 'list-item add-list-item',
+          className: 'list-item add-list-item ' + this.props.classes.listItem,
           onClick: this.handleCreateClick,
         },
         '+ Add New Team'
@@ -83,3 +84,12 @@ export default class CardTeamList extends React.Component {
     return <Card title="Teams">{this.renderTeamList()}</Card>;
   }
 }
+export default injectSheet(theme => ({
+  listItem: {
+    lineHeight: '20px',
+    [`@media (max-width:${theme.breakpoints.sm})`]: {
+      fontSize: '14px',
+      lineHeight: '14px',
+    },
+  },
+}))(CardTeamList);

--- a/src/component-left-header-button.js
+++ b/src/component-left-header-button.js
@@ -9,7 +9,8 @@ const LeftHeaderButton = props =>
       className="back-arrow"
       alt="back"
       style={props.style}
-      onClick={() => {
+      onClick={ev => {
+        ev.preventDefault();
         if (props.onClick) {
           if (props.onClick()) {
             return;

--- a/src/component-right-header-button.js
+++ b/src/component-right-header-button.js
@@ -5,7 +5,8 @@ import { setRoute } from 'actions/route';
 export default class RightHeaderButton extends React.Component {
   constructor(props) {
     super(props);
-    this.handleButtonPress = function() {
+    this.handleButtonPress = function(ev) {
+      ev.preventDefault();
       if (props.onPress) {
         props.onPress();
       }

--- a/src/css/index.js
+++ b/src/css/index.js
@@ -47,6 +47,9 @@ const exp = {
     large: '20rem',
     xLarge: '30rem',
   },
+  breakpoints: {
+    sm: '320px',
+  },
   config: {
     SYNC_DELAY: '10s',
   },

--- a/src/tests/card-spray.test.js
+++ b/src/tests/card-spray.test.js
@@ -1,0 +1,54 @@
+import Enzyme from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import { getPageWrapper } from './test-helpers';
+import state from 'state';
+import { setRoute } from 'actions/route';
+import mockData from './mock.json';
+
+Enzyme.configure({ adapter: new Adapter() });
+state.setOffline();
+
+describe('[UI] Spray', () => {
+  let wrapper = null;
+
+  beforeAll(() => {
+    state.setLocalState(mockData);
+    const { wrapper: localWrapper } = getPageWrapper();
+    wrapper = localWrapper;
+    setRoute(`/`);
+  });
+
+  it('A user can access a spray chart from the players list', () => {
+    wrapper.find(`#players`).simulate('click');
+    wrapper.find(`#player-1ajppp381cecS7`).simulate('click');
+    expect(wrapper.exists('#spray-field')).toEqual(true);
+  });
+
+  it('A user can click a plate appearance to see a tooltip bubble', () => {
+    wrapper.find(`#pa-39AND6zg8BSTB6`).simulate('click');
+    expect(wrapper.exists('#spray-tooltip')).toEqual(true);
+  });
+
+  it('A user can remove a tooltip by clicking on the field', () => {
+    wrapper.find(`#spray-field`).simulate('click');
+    expect(wrapper.exists('#spray-tooltip')).toEqual(false);
+  });
+
+  it('A user can click a tooltip while another tooltip is active', () => {
+    wrapper.find(`#pa-39AND6zg8BSTB6`).simulate('click');
+    expect(wrapper.exists('#spray-tooltip')).toEqual(true);
+    wrapper.find(`#pa-1asNvNz984Ec4f`).simulate('click');
+    expect(wrapper.exists('#spray-tooltip')).toEqual(true);
+  });
+
+  it('A user can click filter through plate appearances', () => {
+    wrapper.find(`#filter-hits`).simulate('click');
+    wrapper.find(`#filter-outs`).simulate('click');
+    wrapper.find(`#filter-extra-hits`).simulate('click');
+    wrapper.find(`#filter-past3`).simulate('click');
+    wrapper.find(`#filter-past5`).simulate('click');
+    wrapper.find(`#filter-past10`).simulate('click');
+    expect(wrapper.exists('#pa-39AND6zg8BSTB6')).toEqual(false);
+    expect(wrapper.exists('#pa-12P8g5t4CwcxBD')).toEqual(true);
+  });
+});

--- a/src/tests/create-edit-delete.test.js
+++ b/src/tests/create-edit-delete.test.js
@@ -23,9 +23,9 @@ export const createTeamUI = wrapper => {
     .simulate('change', { target: { value: TEST_TEAM_NAME } });
   wrapper.find('#save').simulate('click');
 
-  // when the Save button is pressed, the team should be in the state as the last team
+  // when the Save button is pressed, the team should be in the state as the first team
   const teams = state.getLocalState().teams;
-  const newTeam = teams.slice(-1)[0];
+  const newTeam = teams[0];
   expect(newTeam).toBeTruthy();
   expect(newTeam.name).toEqual(TEST_TEAM_NAME);
   expect(newTeam.games.length).toEqual(0);
@@ -43,9 +43,9 @@ export const createGameUI = (wrapper, teamId) => {
   wrapper.find('#lineupType').simulate('change', { target: { value: 1 } });
   wrapper.find('#save').simulate('click');
 
-  // the last game in the list for this team should be the newly-created game
+  // the first game in the list for this team should be the newly-created game
   const games = state.getTeam(teamId).games;
-  const newGame = games.slice(-1)[0];
+  const newGame = games[0];
   expect(newGame).toBeTruthy();
   expect(newGame.opponent).toEqual(TEST_GAME_NAME);
   expect(newGame.lineupType).toEqual(1);

--- a/src/utils/functions.js
+++ b/src/utils/functions.js
@@ -1,3 +1,16 @@
 export const normalize = function(x, A, B, C, D) {
   return C + ((x - A) * (D - C)) / (B - A);
 };
+
+export const sortObjectsByDate = function(list, isAsc) {
+  return list.sort((a, b) => {
+    if (a.date === b.date) {
+      return 0;
+    }
+    if (isAsc) {
+      return a.date < b.date ? -1 : 1;
+    } else {
+      return a.date < b.date ? 1 : -1;
+    }
+  });
+};


### PR DESCRIPTION
This PR makes the game list sort in DESC by date and moves the "+ New Game" button to the top.  The button is also moved for the team list.

![image](https://user-images.githubusercontent.com/1266353/65570027-fbe9e980-df1c-11e9-9353-0c3377610736.png)

This PR also fixes the following bugs:

- Stats page no longer errors when visiting it as a team without data
![file](https://user-images.githubusercontent.com/1266353/65570043-0efcb980-df1d-11e9-9eb9-787063ca5bc4.gif)

- Plate appearance buttons no longer exceed the size of the screen for many iphone screens
![file1](https://user-images.githubusercontent.com/1266353/65570234-ae21b100-df1d-11e9-91b4-838e8a79af0d.gif)

- Team + Game lists now resize their text at smaller resolutions to fit more on the screen
![file2](https://user-images.githubusercontent.com/1266353/65570336-00fb6880-df1e-11e9-8fc4-cb42b7ebddb6.gif)

- A Team and a Game are no longer saved when pressing the back or home buttons
- The user is routed correctly to "home" after clicking the home button on an edit page (which had not been the case)
- A user is no longer shown a public link on the team edit page if they are not logged in
- When editing a Team or a Game, if the user has not modified any fields, they are no longer shown a notification about discarding changes.  This includes the "public link" field.
![file4](https://user-images.githubusercontent.com/1266353/65570521-a0206000-df1e-11e9-9391-7d0e2d73ca89.gif)

