### PR TITLE
Feature: Add filter for ABs to stats table page

### DIFF
--- a/src/cards/card-stats-games.js
+++ b/src/cards/card-stats-games.js
@@ -2,6 +2,7 @@ import React from 'react';
 import ListButton from 'elements/list-button';
 import { sortObjectsByDate, toClientDate } from 'utils/functions';
 import { setRoute } from 'actions/route';
+import state from 'state';
 
 export default class CardStatsSharing extends React.Component {
   constructor(props) {

--- a/src/components/filter-stats.js
+++ b/src/components/filter-stats.js
@@ -1,0 +1,137 @@
+import React from 'react';
+import InnerSection from 'elements/inner-section';
+
+export const getUrlFilterState = () => {
+  const search = new URLSearchParams(window.location.search);
+  let abFilter = parseInt(search.get('ab'));
+  if (isNaN(abFilter) || abFilter < 0) {
+    abFilter = 4;
+  }
+
+  return {
+    filterChecked: search.get('filter') === 'true',
+    abFilter,
+  };
+};
+
+const FilterLabel = (labelProps) => {
+  return (
+    <label
+      {...labelProps}
+      style={{
+        ...(labelProps.style ?? {}),
+        marginLeft: '8px',
+      }}
+    >
+      {labelProps.children}
+    </label>
+  );
+};
+
+// should this reset every time or be stored in local storage?
+let cachedFilterState = null;
+
+export const FilterStats = ({ setFilterState }) => {
+  const [filterState, setLocalFilterState] = React.useState(
+    cachedFilterState ?? getUrlFilterState()
+  );
+
+  const handleEnableFilterChange = (ev) => {
+    setLocalFilterState({
+      ...filterState,
+      filterChecked: ev.target.checked,
+      filterStateChanged: true,
+    });
+  };
+
+  const handleAbFilterChange = (ev) => {
+    setLocalFilterState({
+      ...filterState,
+      abFilter: ev.target.value ?? 0,
+      filterStateChanged: true,
+    });
+  };
+
+  const handleApplyFilterClick = () => {
+    const search = new URLSearchParams(window.location.search);
+    search.set('filter', filterState.filterChecked);
+    search.set('ab', filterState.abFilter);
+    const searchInd = window.location.pathname.indexOf('?');
+    const newUrl =
+      window.location.protocol +
+      '//' +
+      window.location.host +
+      window.location.pathname.slice(
+        0,
+        searchInd === -1 ? undefined : searchInd
+      ) +
+      '?' +
+      search.toString();
+    window.history.replaceState({ path: newUrl }, '', newUrl);
+    const newFilterState = {
+      ...filterState,
+      filterStateChanged: false,
+    };
+    setFilterState(newFilterState);
+    setLocalFilterState(newFilterState);
+    cachedFilterState = newFilterState;
+  };
+
+  React.useEffect(() => {
+    cachedFilterState = null;
+  });
+
+  return (
+    <InnerSection
+      style={{
+        padding: '0px 8px',
+      }}
+    >
+      <h2>Filtering</h2>
+      <p>
+        <input
+          type="checkbox"
+          id="enable-filter"
+          name="enable-filter"
+          checked={filterState.filterChecked}
+          style={{
+            transform: 'scale(1.5)',
+            padding: '8px',
+          }}
+          onChange={handleEnableFilterChange}
+        />
+        <FilterLabel htmlFor="enable-filter">Enable filtering</FilterLabel>
+        <br />
+        <br />
+        <input
+          type="number"
+          name="ab-filter"
+          style={{
+            width: '48px',
+            padding: '8px',
+          }}
+          value={filterState.abFilter}
+          disabled={!filterState.filterChecked}
+          onChange={handleAbFilterChange}
+        ></input>
+        <FilterLabel htmlFor="ab-filter">Minimum # of ABs</FilterLabel>
+        <br />
+        <br />
+        <button
+          className="button primary-button"
+          style={{
+            marginLeft: '0px',
+            opacity: filterState.filterStateChanged ? 1 : 0.5,
+            pointerEvents: filterState.filterStateChanged ? 'auto' : 'none',
+          }}
+          disabled={filterState.filterStateChanged === false}
+          onClick={handleApplyFilterClick}
+        >
+          {!filterState.filterChecked && filterState.filterStateChanged
+            ? 'Remove Filter'
+            : 'Apply Filter'}
+        </button>
+      </p>
+    </InnerSection>
+  );
+};

--- a/src/components/game-scorer.js
+++ b/src/components/game-scorer.js
@@ -2,7 +2,6 @@ import React from 'react';
 import CardSection from 'elements/card-section';
 import state from 'state';
 import { makeStyles } from 'css/helpers';
-import css from 'css';
 
 const useScorePaperStyles = makeStyles((css) => ({
   root: {
@@ -125,73 +124,77 @@ const ScoreTable = ({ usName, themName, game }) => {
   return (
     <table className={classes.table}>
       <thead>
-        <th
-          style={{ borderTop: 0, borderLeft: 0 }}
-          className={classes.tableCell}
-        ></th>
-        <th className={classes.tableCell}>1</th>
-        <th className={classes.tableCell}>2</th>
-        <th className={classes.tableCell}>3</th>
-        <th className={classes.tableCell}>4</th>
-        <th className={classes.tableCell}>5</th>
-        <th className={classes.tableCell}>6</th>
-        <th className={classes.tableCell}>7</th>
+        <tr>
+          <th
+            style={{ borderTop: 0, borderLeft: 0 }}
+            className={classes.tableCell}
+          ></th>
+          <th className={classes.tableCell}>1</th>
+          <th className={classes.tableCell}>2</th>
+          <th className={classes.tableCell}>3</th>
+          <th className={classes.tableCell}>4</th>
+          <th className={classes.tableCell}>5</th>
+          <th className={classes.tableCell}>6</th>
+          <th className={classes.tableCell}>7</th>
+        </tr>
       </thead>
-      <tr>
-        <td className={classes.tableCell}>{usName}</td>
-        <TableCell
-          inning="1"
-          game={game}
-          whoseScore="scoreUs"
-          score={scores[0]}
-        />
-        <TableCell
-          inning="2"
-          game={game}
-          whoseScore="scoreUs"
-          score={scores[1]}
-        />
-        <TableCell
-          inning="3"
-          game={game}
-          whoseScore="scoreUs"
-          score={scores[2]}
-        />
-        <TableCell
-          inning="4"
-          game={game}
-          whoseScore="scoreUs"
-          score={scores[3]}
-        />
-        <TableCell
-          inning="5"
-          game={game}
-          whoseScore="scoreUs"
-          score={scores[4]}
-        />
-        <TableCell
-          inning="6"
-          game={game}
-          whoseScore="scoreUs"
-          score={scores[5]}
-        />
-        <TableCell
-          inning="7"
-          game={game}
-          whoseScore="scoreUs"
-          score={scores[6]}
-        />
-      </tr>
-      <tr>
-        <td className={classes.tableCell}>{themName}</td>
-        <TableCell inning="1" game={game} whoseScore="scoreThem" />
-        <TableCell inning="2" game={game} whoseScore="scoreThem" />
-        <TableCell inning="3" game={game} whoseScore="scoreThem" />
-        <TableCell inning="4" game={game} whoseScore="scoreThem" />
-        <TableCell inning="5" game={game} whoseScore="scoreThem" />
-        <TableCell inning="6" game={game} whoseScore="scoreThem" />
-        <TableCell inning="7" game={game} whoseScore="scoreThem" />
-      </tr>
+      <tbody>
+        <tr>
+          <td className={classes.tableCell}>{usName}</td>
+          <TableCell
+            inning="1"
+            game={game}
+            whoseScore="scoreUs"
+            score={scores[0]}
+          />
+          <TableCell
+            inning="2"
+            game={game}
+            whoseScore="scoreUs"
+            score={scores[1]}
+          />
+          <TableCell
+            inning="3"
+            game={game}
+            whoseScore="scoreUs"
+            score={scores[2]}
+          />
+          <TableCell
+            inning="4"
+            game={game}
+            whoseScore="scoreUs"
+            score={scores[3]}
+          />
+          <TableCell
+            inning="5"
+            game={game}
+            whoseScore="scoreUs"
+            score={scores[4]}
+          />
+          <TableCell
+            inning="6"
+            game={game}
+            whoseScore="scoreUs"
+            score={scores[5]}
+          />
+          <TableCell
+            inning="7"
+            game={game}
+            whoseScore="scoreUs"
+            score={scores[6]}
+          />
+        </tr>
+        <tr>
+          <td className={classes.tableCell}>{themName}</td>
+          <TableCell inning="1" game={game} whoseScore="scoreThem" />
+          <TableCell inning="2" game={game} whoseScore="scoreThem" />
+          <TableCell inning="3" game={game} whoseScore="scoreThem" />
+          <TableCell inning="4" game={game} whoseScore="scoreThem" />
+          <TableCell inning="5" game={game} whoseScore="scoreThem" />
+          <TableCell inning="6" game={game} whoseScore="scoreThem" />
+          <TableCell inning="7" game={game} whoseScore="scoreThem" />
+        </tr>
+      </tbody>
     </table>
   );
 };

--- a/src/elements/icon-button.js
+++ b/src/elements/icon-button.js
@@ -10,7 +10,7 @@ id?: string
 onClick?: () => void
 */
 const IconButton = (props) => {
-  const { hideBackground, invert, opacity, ...rest } = props;
+  const { hideBackground, invert, opacity, containerStyle, ...rest } = props;
   return (
     <div
       className="hover"
@@ -21,6 +21,7 @@ const IconButton = (props) => {
         height: '24px',
         padding: '12px', // 24x24 + 12 + 12 padding => minimum accessible tap target size
         opacity: opacity,
+        ...(containerStyle ?? {}),
       }}
     >
       <img alt="img" {...rest} />

--- a/src/state.js
+++ b/src/state.js
@@ -1486,13 +1486,13 @@ exp.buildStatsObject = function (plateAppearances, playerId) {
     ? paAutoCorResult.toFixed(2)
     : '-';
 
-  if (isStatSig(paAutoCorResult, hitOrNoHit.length)) {
-    console.log(
-      stats.name,
-      isStatSig(paAutoCorResult, hitOrNoHit.length),
-      hitOrNoHit
-    );
-  }
+  // if (isStatSig(paAutoCorResult, hitOrNoHit.length)) {
+  //   console.log(
+  //     stats.name,
+  //     isStatSig(paAutoCorResult, hitOrNoHit.length),
+  //     hitOrNoHit
+  //   );
+  // }
 
   // Serial correlation for games
   // TODO: we want this sorted by date right?
@@ -1521,9 +1521,9 @@ exp.buildStatsObject = function (plateAppearances, playerId) {
     avgList.push(hits / count);
   });
   let autoCorResult = autoCorrelation(avgList, 1);
-  if (isStatSig(autoCorResult, avgList.length)) {
-    console.log(stats.name, isStatSig(autoCorResult, avgList.length), avgList);
-  }
+  // if (isStatSig(autoCorResult, avgList.length)) {
+  //   console.log(stats.name, isStatSig(autoCorResult, avgList.length), avgList);
+  // }
   stats.gameAutocorrelation = isStatSig(autoCorResult, avgList.length)
     ? autoCorResult.toFixed(2)
     : '-';


### PR DESCRIPTION
- Added filter to stats page to filter by minimum number of at bats.  The filter changes the url so on the public url page you can copy the link and everybody will see what you see.
- Fixed some dom nesting errors I was seeing on the <table> in the scorer
- Moved helper text to top of stats table page and added "Click Me" text next to the help icon because of the feedback that nobody knew you could click that.

![filter-by-ab](https://github.com/thbrown/softball-scorer/assets/1266353/52a72340-a579-4e22-b078-431351e925db)