### PR TITLE
Fix an issue where the ball field is offset by 19px

### DIFF
--- a/src/cards/card-plate-appearance.js
+++ b/src/cards/card-plate-appearance.js
@@ -1036,14 +1036,6 @@ class CardPlateAppearance extends React.Component {
         {textInfo}
         {runnerObjects}
         <BallFieldSvg />
-        {/* <img
-          //draggable={true}
-          src="/assets/ballfield2.png"
-          alt="ballfield"
-          style={{
-            width: '100%',
-          }}
-        ></img> */}
         {indicators}
       </div>
     );

--- a/src/cards/card-plate-appearance.js
+++ b/src/cards/card-plate-appearance.js
@@ -8,6 +8,7 @@ import { normalize, distance, cleanObject } from 'utils/functions';
 import { goBack } from 'actions/route';
 import { makeStyles } from 'css/helpers';
 import Card from 'elements/card';
+import BallFieldSvg from 'components/ball-field-svg';
 
 const LOCATION_DENOMINATOR = 32767;
 
@@ -301,7 +302,7 @@ class CardPlateAppearance extends React.Component {
           cleanRunners['3B'] = cleanRunners['scored'][0];
           cleanRunners['scored'] = [];
         } else {
-          logger.warn('Could not find a base for the runner!');
+          console.warn('Could not find a base for the runner!');
         }
       }
 
@@ -1001,6 +1002,7 @@ class CardPlateAppearance extends React.Component {
           display: 'flex',
           justifyContent: 'space-evenly',
           position: 'relative',
+          height: '19px',
         }}
       >
         <div>
@@ -1033,14 +1035,15 @@ class CardPlateAppearance extends React.Component {
       >
         {textInfo}
         {runnerObjects}
-        <img
+        <BallFieldSvg />
+        {/* <img
           //draggable={true}
           src="/assets/ballfield2.png"
           alt="ballfield"
           style={{
             width: '100%',
           }}
-        ></img>
+        ></img> */}
         {indicators}
       </div>
     );

--- a/src/components/spray.js
+++ b/src/components/spray.js
@@ -224,6 +224,8 @@ const Field = enhanceField((props) => {
         overflow: 'hidden',
       }}
     >
+      {/* HACK: The spray field indicators for the 2023 season are offset by 19px
+      because of a visual bug on the PA page. Should we move them up? */}
       <div
         style={{
           height: '19px',

--- a/src/components/spray.js
+++ b/src/components/spray.js
@@ -217,10 +217,18 @@ const Field = enhanceField((props) => {
       }}
       style={{
         position: 'relative',
+        borderTop: '1px solid white',
+        borderBottom: '1px solid white',
         width: Math.min(window.innerWidth, BALL_FIELD_MAX_WIDTH) + 'px',
         height: Math.min(window.innerWidth, BALL_FIELD_MAX_WIDTH) + 'px',
+        overflow: 'hidden',
       }}
     >
+      <div
+        style={{
+          height: '19px',
+        }}
+      ></div>
       <BallFieldSvg />
       {indicators}
       {props.paTooltip ? (

--- a/src/state.js
+++ b/src/state.js
@@ -355,7 +355,7 @@ exp.sync = async function (fullSync) {
           err,
         () => {}
       );
-      console.warn(e.stack);
+      console.warn(err.stack);
       setSyncState(SYNC_STATUS_ENUM.ERROR);
     }
     return err.message;


### PR DESCRIPTION
On the plate appearance page, the banner that indicates the score, inning, and number of outs offsets the ball field by 19px vertically.  When you view this spray chart on other screens (like from the stats area), you can see that the markers are off in the vertical direction and that the whole ball field is shifted down.

Plate Appearance Page
![image](https://github.com/thbrown/softball-scorer/assets/1266353/dadd7149-ce8d-4c78-99d8-a0abfaea54b3)

Spray Chart for a game
![image](https://github.com/thbrown/softball-scorer/assets/1266353/b356c8fe-c3e6-4820-9d3f-ce64d8fc428f)

This means that all data from 2023 since that change is 19px too low.

In addition, the ball field is using the old .png image that was replaced last November.  This PR fixes the ball field, but I think we should consider fixing the data instead of the fix in this PR that adds the 19px gap to the spray charts.

The fix:
![image](https://github.com/thbrown/softball-scorer/assets/1266353/1257db8d-17cb-4e1d-b249-b49ee2e36e08)

