### PR TITLE
Remove redundant save to local storage on edit that can be done on sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "got": "^11.8.0",
     "helmet": "^4.2.0",
     "jsonpointer": "^5.0.1",
+    "localforage": "^1.10.0",
     "lz-string": "^1.4.4",
     "mailgun.js": "^6.0.1",
     "node-object-hash": "^2.3.10",

--- a/src/state.js
+++ b/src/state.js
@@ -1266,6 +1266,7 @@ exp.setAccountOptimizersList = function (newOptimizersArray) {
 // LOCAL STORAGE
 exp.saveDbStateToLocalStorage = function () {
   if (typeof Storage !== 'undefined') {
+    console.log('save local storage state');
     /*
     // Disable compression for now
     let compressedLocalState = LZString.compress(
@@ -1390,13 +1391,6 @@ exp.clearLocalStorage = function () {
 
 function onEdit() {
   reRender();
-  try {
-    exp.saveDbStateToLocalStorage();
-  } catch (e) {
-    console.warn('Could not persist edit locally, restoring. ', e);
-    exp.loadStateFromLocalStorage(true, false);
-    reRender();
-  }
   exp.scheduleSync();
 }
 

--- a/src/state.js
+++ b/src/state.js
@@ -4,7 +4,7 @@ import SharedLib from 'shared-lib';
 import results from 'plate-appearance-results';
 import { getShallowCopy, autoCorrelation, isStatSig } from 'utils/functions';
 import StateIndex from 'state-index';
-
+import localForage from 'localforage';
 import dialog from 'dialog';
 const TLSchemas = SharedLib.schemaValidation.TLSchemas;
 
@@ -72,6 +72,21 @@ let syncTimerTimestamp = null;
 let INDEX = new StateIndex(LOCAL_DB_STATE);
 
 const state = exp;
+
+const internalLocalStorage = {
+  setItem: async (key, value) => {
+    localForage.setItem(key, value);
+  },
+  getItem: async (key) => {
+    const item = localForage.getItem(key);
+    if (!item) {
+      return localStorage.getItem(key);
+    }
+  },
+  clear: async () => {
+    return localForage.clear();
+  },
+};
 
 // New objects shapes
 const getNewTeam = function (teamName) {
@@ -1264,8 +1279,9 @@ exp.setAccountOptimizersList = function (newOptimizersArray) {
 };
 
 // LOCAL STORAGE
-exp.saveDbStateToLocalStorage = function () {
+exp.saveDbStateToLocalStorage = async function () {
   if (typeof Storage !== 'undefined') {
+    console.log('save local storage state');
     /*
     // Disable compression for now
     let compressedLocalState = LZString.compress(
@@ -1281,45 +1297,63 @@ exp.saveDbStateToLocalStorage = function () {
     */
     SharedLib.schemaValidation.validateSchema(LOCAL_DB_STATE, TLSchemas.CLIENT);
 
-    localStorage.setItem('SCHEMA_VERSION', CURRENT_LS_SCHEMA_VERSION);
-    localStorage.setItem('LOCAL_DB_STATE', JSON.stringify(LOCAL_DB_STATE));
-    localStorage.setItem(
+    await internalLocalStorage.setItem(
+      'SCHEMA_VERSION',
+      CURRENT_LS_SCHEMA_VERSION
+    );
+    await internalLocalStorage.setItem(
+      'LOCAL_DB_STATE',
+      JSON.stringify(LOCAL_DB_STATE)
+    );
+    await internalLocalStorage.setItem(
       'ANCESTOR_DB_STATE',
       JSON.stringify(ANCESTOR_DB_STATE)
     );
   }
 };
 
-exp.saveApplicationStateToLocalStorage = function () {
+exp.saveApplicationStateToLocalStorage = async function () {
   if (typeof Storage !== 'undefined') {
-    localStorage.setItem('SCHEMA_VERSION', CURRENT_LS_SCHEMA_VERSION);
+    await internalLocalStorage.setItem(
+      'SCHEMA_VERSION',
+      CURRENT_LS_SCHEMA_VERSION
+    );
     let applicationState = {
       online: online,
       sessionValid: sessionValid,
       activeUser: activeUser,
     };
-    localStorage.setItem('APPLICATION_STATE', JSON.stringify(applicationState));
+    await internalLocalStorage.setItem(
+      'APPLICATION_STATE',
+      JSON.stringify(applicationState)
+    );
   }
 };
 
-exp.loadStateFromLocalStorage = function (loadState = true, loadApp = true) {
+exp.loadStateFromLocalStorage = async function (
+  loadState = true,
+  loadApp = true
+) {
   if (typeof Storage !== 'undefined') {
     // These statements define local storage schema migrations
-    if (localStorage.getItem('SCHEMA_VERSION') !== CURRENT_LS_SCHEMA_VERSION) {
+    const version = await internalLocalStorage.getItem('SCHEMA_VERSION');
+    if (version !== CURRENT_LS_SCHEMA_VERSION) {
       console.log(
-        `Removing invalid localStorage data ${localStorage.getItem(
+        `Removing invalid localStorage data ${internalLocalStorage.getItem(
           'SCHEMA_VERSION'
         )}`
       );
-      exp.clearLocalStorage();
-      exp.saveDbStateToLocalStorage();
-      exp.saveApplicationStateToLocalStorage();
+      await exp.clearLocalStorage();
+      await exp.saveDbStateToLocalStorage();
+      await exp.saveApplicationStateToLocalStorage();
     }
 
     // Retrieve, update, and validate state. Do nothing if anything in this process fails.
     if (loadState) {
       try {
-        let localDbState = JSON.parse(localStorage.getItem('LOCAL_DB_STATE'));
+        let localDbState = JSON.parse(
+          await internalLocalStorage.getItem('LOCAL_DB_STATE')
+        );
         if (localDbState) {
           SharedLib.schemaMigration.updateSchema(null, localDbState, 'client');
           SharedLib.schemaValidation.validateSchema(
@@ -1329,7 +1363,7 @@ exp.loadStateFromLocalStorage = function (loadState = true, loadApp = true) {
         }
 
         let ancestorDbState = JSON.parse(
-          localStorage.getItem('ANCESTOR_DB_STATE')
+          await internalLocalStorage.getItem('ANCESTOR_DB_STATE')
         );
         if (ancestorDbState) {
           SharedLib.schemaMigration.updateSchema(
@@ -1358,10 +1392,9 @@ exp.loadStateFromLocalStorage = function (loadState = true, loadApp = true) {
     }
 
     if (loadApp) {
-      let applicationState = JSON.parse(
-        localStorage.getItem('APPLICATION_STATE')
-      );
-      if (applicationState) {
+      const stateJson = await internalLocalStorage.getItem('APPLICATION_STATE');
+      if (stateJson) {
+        const applicationState = JSON.parse(stateJson);
         online = applicationState.online ? applicationState.online : true;
         sessionValid = applicationState.sessionValid
           ? applicationState.sessionValid
@@ -1381,15 +1414,22 @@ exp.loadStateFromLocalStorage = function (loadState = true, loadApp = true) {
   reRender();
 };
 
-exp.clearLocalStorage = function () {
+exp.clearLocalStorage = async function () {
   console.log('Clearing ls ');
-  localStorage.clear();
+  return internalLocalStorage.clear();
 };
 
 // HELPERS
 
-function onEdit() {
+async function onEdit() {
   reRender();
+  try {
+    await exp.saveDbStateToLocalStorage();
+  } catch (e) {
+    console.warn('Could not persist edit locally, restoring. ', e);
+    exp.loadStateFromLocalStorage(true, false);
+    reRender();
+  }
   exp.scheduleSync();
 }
 

--- a/src/state.js
+++ b/src/state.js
@@ -1266,7 +1266,6 @@ exp.setAccountOptimizersList = function (newOptimizersArray) {
 // LOCAL STORAGE
 exp.saveDbStateToLocalStorage = function () {
   if (typeof Storage !== 'undefined') {
-    console.log('save local storage state');
     /*
     // Disable compression for now
     let compressedLocalState = LZString.compress(

--- a/yarn.lock
+++ b/yarn.lock
@@ -6037,6 +6037,11 @@ ignore@^5.2.0:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
   integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
 
+immediate@~3.0.5:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
+  integrity sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==
+
 import-fresh@^3.0.0, import-fresh@^3.1.0, import-fresh@^3.2.1:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"
@@ -7382,6 +7387,13 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+lie@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/lie/-/lie-3.1.1.tgz#9a436b2cc7746ca59de7a41fa469b3efb76bd87e"
+  integrity sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==
+  dependencies:
+    immediate "~3.0.5"
+
 lines-and-columns@^1.1.6:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
@@ -7410,6 +7422,13 @@ loader-utils@^2.0.0:
     big.js "^5.2.2"
     emojis-list "^3.0.0"
     json5 "^2.1.2"
+
+localforage@^1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/localforage/-/localforage-1.10.0.tgz#5c465dc5f62b2807c3a84c0c6a1b1b3212781dd4"
+  integrity sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==
+  dependencies:
+    lie "3.1.1"
 
 locate-path@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
The function `saveDbStateToLocalStorage` in state.js is expensive.  This function is getting called in the onEdit helper as well as whenever a sync happens.

limiting my pc to 6x slowdown shows a 275ms spike whenever editing a plate appearance, which is exacerbated on phones especially as they get queued.

![image](https://github.com/thbrown/softball-scorer/assets/1266353/5cddde75-c62a-4d57-a140-e2f45f338fe9)

Since it is so expensive, I think it should only attempt to save to LS on sync instead of on every edit, because it causes phones to hang/low fps for the moments it is saving. 

An alternative solution might be to make this function less expensive: validate only on edit, or else use indexdb instead of local storage to remove the limit on space local storage has.