### PR TITLE
Add LocalForage library to use indexdb

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "got": "^11.8.0",
     "helmet": "^4.2.0",
     "jsonpointer": "^5.0.1",
+    "localforage": "^1.10.0",
     "lz-string": "^1.4.4",
     "mailgun.js": "^6.0.1",
     "node-object-hash": "^2.3.10",

--- a/src/cards/card-import.js
+++ b/src/cards/card-import.js
@@ -70,7 +70,7 @@ const CardImport = () => {
     const file = fileInputRef.current.files[0];
     if (file) {
       const reader = new FileReader();
-      reader.onload = function (e) {
+      reader.onload = async function (e) {
         let parsedData;
         try {
           parsedData = JSON.parse(e.target.result);
@@ -112,7 +112,7 @@ const CardImport = () => {
             true
           );
 
-          state.setLocalState(patched);
+          await state.setLocalState(patched);
         } else if (loadType === 'theirs') {
           const localToPatch = SharedLib.objectMerge.diff(
             state.getLocalState(),
@@ -129,7 +129,7 @@ const CardImport = () => {
           // Changes in the patch win, so we need changes this from "export" to "client" manually
           patched.metadata.scope = 'client';
 
-          state.setLocalState(patched);
+          await state.setLocalState(patched);
         } else {
           dialog.show_notification(
             'Please select load type option before clicking "Load".'

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ global.React = React;
 const container = document.createElement('div');
 document.body.prepend(container);
 
-let Main = (global.Main = {
+const Main = (global.Main = {
   render: () => void 0,
 });
 
@@ -56,10 +56,10 @@ const App = (props) => {
   );
 };
 
-(function () {
-  let root = ReactDOM.createRoot(container);
+state.loadStateFromLocalStorage().then(() => {
+  const root = ReactDOM.createRoot(container);
   root.render(<App />);
-})();
+});
 
 let _resize_timeout = null;
 window.addEventListener('resize', function () {

--- a/src/main-container.js
+++ b/src/main-container.js
@@ -70,9 +70,6 @@ export default class MainContainer extends expose.Component {
 
     // TODO: if(test) logic should be removed and we should find a way to mock problematic APIs
     if (!this.props.test) {
-      // Load data from localstorage synchronously
-      state.loadStateFromLocalStorage();
-
       // Reload from local storage each time after the window regains focus
       window.addEventListener(
         'focus',

--- a/src/state.js
+++ b/src/state.js
@@ -162,7 +162,9 @@ exp.sync = async function (fullSync) {
   setSyncState(SYNC_STATUS_ENUM.IN_PROGRESS);
   try {
     // Save a deep copy of the local state
-    let localStateCopyPreRequest = structuredClone(state.getLocalState());
+    let localStateCopyPreRequest = JSON.parse(
+      JSON.stringify(state.getLocalState())
+    );
     let localState = state.getLocalState();
 
     // Save the ancestor state so we can restore it if something goes wrong
@@ -302,7 +304,7 @@ exp.sync = async function (fullSync) {
       reRender();
 
       // Write the most updated data to local storage
-      exp.saveDbStateToLocalStorage();
+      await exp.saveDbStateToLocalStorage();
     } else {
       throw new Error(response.status);
     }
@@ -380,7 +382,7 @@ exp.resetSyncState = function () {
   setSyncState(SYNC_STATUS_ENUM.UNKNOWN);
 };
 
-exp.resetState = function () {
+exp.resetState = async function () {
   setSyncState(SYNC_STATUS_ENUM.UNKNOWN);
 
   online = true;
@@ -391,8 +393,8 @@ exp.resetState = function () {
   ANCESTOR_DB_STATE = JSON.parse(JSON.stringify(INITIAL_STATE));
   INDEX = new StateIndex(LOCAL_DB_STATE);
 
-  exp.saveApplicationStateToLocalStorage();
-  exp.saveDbStateToLocalStorage();
+  await exp.saveApplicationStateToLocalStorage();
+  await exp.saveDbStateToLocalStorage();
 };
 
 exp.deleteAllData = function () {
@@ -1418,7 +1420,7 @@ async function onEdit() {
     await exp.saveDbStateToLocalStorage();
   } catch (e) {
     console.warn('Could not persist edit locally, restoring. ', e);
-    exp.loadStateFromLocalStorage(true, false);
+    await exp.loadStateFromLocalStorage(true, false);
     reRender();
   }
   exp.scheduleSync();

--- a/src/state.js
+++ b/src/state.js
@@ -1338,11 +1338,7 @@ exp.loadStateFromLocalStorage = async function (
     // These statements define local storage schema migrations
     const version = await internalLocalStorage.getItem('SCHEMA_VERSION');
     if (version !== CURRENT_LS_SCHEMA_VERSION) {
-      console.log(
-        `Removing invalid localStorage data ${internalLocalStorage.getItem(
-          'SCHEMA_VERSION'
-        )}`
-      );
+      console.log(`Removing invalid localStorage data ${version}`);
       await exp.clearLocalStorage();
       await exp.saveDbStateToLocalStorage();
       await exp.saveApplicationStateToLocalStorage();

--- a/src/state.js
+++ b/src/state.js
@@ -1281,7 +1281,6 @@ exp.setAccountOptimizersList = function (newOptimizersArray) {
 // LOCAL STORAGE
 exp.saveDbStateToLocalStorage = async function () {
   if (typeof Storage !== 'undefined') {
-    console.log('save local storage state');
     /*
     // Disable compression for now
     let compressedLocalState = LZString.compress(

--- a/src/state.js
+++ b/src/state.js
@@ -75,7 +75,7 @@ const state = exp;
 
 const internalLocalStorage = {
   setItem: async (key, value) => {
-    localForage.setItem(key, value);
+    return localForage.setItem(key, value);
   },
   getItem: async (key) => {
     const item = localForage.getItem(key);

--- a/src/state.js
+++ b/src/state.js
@@ -4,7 +4,7 @@ import SharedLib from 'shared-lib';
 import results from 'plate-appearance-results';
 import { getShallowCopy, autoCorrelation, isStatSig } from 'utils/functions';
 import StateIndex from 'state-index';
-
+import localForage from 'localforage';
 import dialog from 'dialog';
 const TLSchemas = SharedLib.schemaValidation.TLSchemas;
 
@@ -72,6 +72,21 @@ let syncTimerTimestamp = null;
 let INDEX = new StateIndex(LOCAL_DB_STATE);
 
 const state = exp;
+
+const internalLocalStorage = {
+  setItem: async (key, value) => {
+    localForage.setItem(key, value);
+  },
+  getItem: async (key) => {
+    const item = localForage.getItem(key);
+    if (!item) {
+      return localStorage.getItem(key);
+    }
+  },
+  clear: async () => {
+    return localForage.clear();
+  },
+};
 
 // New objects shapes
 const getNewTeam = function (teamName) {
@@ -395,11 +410,11 @@ exp.getLocalStateChecksum = function () {
   return SharedLib.commonUtils.getHash(LOCAL_DB_STATE);
 };
 
-exp.setLocalState = function (newState) {
+exp.setLocalState = async function (newState) {
   SharedLib.schemaValidation.validateSchema(newState, TLSchemas.CLIENT);
   LOCAL_DB_STATE = newState;
   INDEX = new StateIndex(LOCAL_DB_STATE);
-  onEdit();
+  await onEdit();
 };
 
 let setLocalStateNoSideEffects = function (newState) {
@@ -1264,8 +1279,9 @@ exp.setAccountOptimizersList = function (newOptimizersArray) {
 };
 
 // LOCAL STORAGE
-exp.saveDbStateToLocalStorage = function () {
+exp.saveDbStateToLocalStorage = async function () {
   if (typeof Storage !== 'undefined') {
+    console.log('save local storage state');
     /*
     // Disable compression for now
     let compressedLocalState = LZString.compress(
@@ -1281,45 +1297,63 @@ exp.saveDbStateToLocalStorage = function () {
     */
     SharedLib.schemaValidation.validateSchema(LOCAL_DB_STATE, TLSchemas.CLIENT);
 
-    localStorage.setItem('SCHEMA_VERSION', CURRENT_LS_SCHEMA_VERSION);
-    localStorage.setItem('LOCAL_DB_STATE', JSON.stringify(LOCAL_DB_STATE));
-    localStorage.setItem(
+    await internalLocalStorage.setItem(
+      'SCHEMA_VERSION',
+      CURRENT_LS_SCHEMA_VERSION
+    );
+    await internalLocalStorage.setItem(
+      'LOCAL_DB_STATE',
+      JSON.stringify(LOCAL_DB_STATE)
+    );
+    await internalLocalStorage.setItem(
       'ANCESTOR_DB_STATE',
       JSON.stringify(ANCESTOR_DB_STATE)
     );
   }
 };
 
-exp.saveApplicationStateToLocalStorage = function () {
+exp.saveApplicationStateToLocalStorage = async function () {
   if (typeof Storage !== 'undefined') {
-    localStorage.setItem('SCHEMA_VERSION', CURRENT_LS_SCHEMA_VERSION);
+    await internalLocalStorage.setItem(
+      'SCHEMA_VERSION',
+      CURRENT_LS_SCHEMA_VERSION
+    );
     let applicationState = {
       online: online,
       sessionValid: sessionValid,
       activeUser: activeUser,
     };
-    localStorage.setItem('APPLICATION_STATE', JSON.stringify(applicationState));
+    await internalLocalStorage.setItem(
+      'APPLICATION_STATE',
+      JSON.stringify(applicationState)
+    );
   }
 };
 
-exp.loadStateFromLocalStorage = function (loadState = true, loadApp = true) {
+exp.loadStateFromLocalStorage = async function (
+  loadState = true,
+  loadApp = true
+) {
   if (typeof Storage !== 'undefined') {
     // These statements define local storage schema migrations
-    if (localStorage.getItem('SCHEMA_VERSION') !== CURRENT_LS_SCHEMA_VERSION) {
+    const version = await internalLocalStorage.getItem('SCHEMA_VERSION');
+    if (version !== CURRENT_LS_SCHEMA_VERSION) {
       console.log(
-        `Removing invalid localStorage data ${localStorage.getItem(
+        `Removing invalid localStorage data ${internalLocalStorage.getItem(
           'SCHEMA_VERSION'
         )}`
       );
-      exp.clearLocalStorage();
-      exp.saveDbStateToLocalStorage();
-      exp.saveApplicationStateToLocalStorage();
+      await exp.clearLocalStorage();
+      await exp.saveDbStateToLocalStorage();
+      await exp.saveApplicationStateToLocalStorage();
     }
 
     // Retrieve, update, and validate state. Do nothing if anything in this process fails.
     if (loadState) {
       try {
-        let localDbState = JSON.parse(localStorage.getItem('LOCAL_DB_STATE'));
+        let localDbState = JSON.parse(
+          await internalLocalStorage.getItem('LOCAL_DB_STATE')
+        );
         if (localDbState) {
           SharedLib.schemaMigration.updateSchema(null, localDbState, 'client');
           SharedLib.schemaValidation.validateSchema(
@@ -1329,7 +1363,7 @@ exp.loadStateFromLocalStorage = function (loadState = true, loadApp = true) {
         }
 
         let ancestorDbState = JSON.parse(
-          localStorage.getItem('ANCESTOR_DB_STATE')
+          await internalLocalStorage.getItem('ANCESTOR_DB_STATE')
         );
         if (ancestorDbState) {
           SharedLib.schemaMigration.updateSchema(
@@ -1358,10 +1392,9 @@ exp.loadStateFromLocalStorage = function (loadState = true, loadApp = true) {
     }
 
     if (loadApp) {
-      let applicationState = JSON.parse(
-        localStorage.getItem('APPLICATION_STATE')
-      );
-      if (applicationState) {
+      const stateJson = await internalLocalStorage.getItem('APPLICATION_STATE');
+      if (stateJson) {
+        const applicationState = JSON.parse(stateJson);
         online = applicationState.online ? applicationState.online : true;
         sessionValid = applicationState.sessionValid
           ? applicationState.sessionValid
@@ -1381,17 +1414,17 @@ exp.loadStateFromLocalStorage = function (loadState = true, loadApp = true) {
   reRender();
 };
 
-exp.clearLocalStorage = function () {
+exp.clearLocalStorage = async function () {
   console.log('Clearing ls ');
-  localStorage.clear();
+  return internalLocalStorage.clear();
 };
 
 // HELPERS
 
-function onEdit() {
+async function onEdit() {
   reRender();
   try {
-    exp.saveDbStateToLocalStorage();
+    await exp.saveDbStateToLocalStorage();
   } catch (e) {
     console.warn('Could not persist edit locally, restoring. ', e);
     exp.loadStateFromLocalStorage(true, false);
@@ -1697,14 +1730,14 @@ exp.getActiveUser = function () {
   return activeUser;
 };
 
-exp.setOffline = function () {
+exp.setOffline = async function () {
   online = false;
-  exp.saveApplicationStateToLocalStorage();
+  await exp.saveApplicationStateToLocalStorage();
 };
 
-exp.setActiveUser = function (user) {
+exp.setActiveUser = async function (user) {
   activeUser = user;
-  exp.saveApplicationStateToLocalStorage();
+  await exp.saveApplicationStateToLocalStorage();
 };
 
 exp.setStatusBasedOnHttpResponse = function (code, isAuthRequest) {

--- a/src/tests/card-game-stats.test.js
+++ b/src/tests/card-game-stats.test.js
@@ -12,10 +12,10 @@ describe('[UI] Game Stats', () => {
   let wrapper = null;
   let _isSessionValid = state.isSessionValid;
 
-  beforeAll(() => {
+  beforeAll(async () => {
     state.setOffline();
     SharedLib.schemaMigration.updateSchema(null, mockData, 'client');
-    state.setLocalState(mockData);
+    await state.setLocalState(mockData);
     const { wrapper: localWrapper } = getPageWrapper();
     wrapper = localWrapper;
     setRoute(`/`);

--- a/src/tests/card-optimization-lineup-import.test.js
+++ b/src/tests/card-optimization-lineup-import.test.js
@@ -15,10 +15,10 @@ const GAME_ID = '1';
 describe('[UI] Optimization', () => {
   let wrapper = null;
 
-  beforeAll(() => {
+  beforeAll(async () => {
     state.setOffline();
     SharedLib.schemaMigration.updateSchema(null, mockData, 'client');
-    state.setLocalState(mockData);
+    await state.setLocalState(mockData);
     const { wrapper: localWrapper } = getPageWrapper();
     wrapper = localWrapper;
     window.scroll = () => void 0;

--- a/src/tests/card-player-edit.test.js
+++ b/src/tests/card-player-edit.test.js
@@ -11,10 +11,10 @@ Enzyme.configure({ adapter: new Adapter() });
 describe('[UI] Card Player Edit', () => {
   let wrapper = null;
 
-  beforeAll(() => {
+  beforeAll(async () => {
     state.setOffline();
     SharedLib.schemaMigration.updateSchema(null, mockData, 'client');
-    state.setLocalState(mockData);
+    await state.setLocalState(mockData);
     const { wrapper: localWrapper } = getPageWrapper();
     wrapper = localWrapper;
     setRoute(`/`);

--- a/src/tests/card-spray.test.js
+++ b/src/tests/card-spray.test.js
@@ -11,10 +11,10 @@ Enzyme.configure({ adapter: new Adapter() });
 describe('[UI] Spray', () => {
   let wrapper = null;
 
-  beforeAll(() => {
+  beforeAll(async () => {
     state.setOffline();
     SharedLib.schemaMigration.updateSchema(null, mockData, 'client');
-    state.setLocalState(mockData);
+    await state.setLocalState(mockData);
     const { wrapper: localWrapper } = getPageWrapper();
     wrapper = localWrapper;
     setRoute(`/`);

--- a/src/tests/load-from-file.test.js
+++ b/src/tests/load-from-file.test.js
@@ -11,20 +11,20 @@ Enzyme.configure({ adapter: new Adapter() });
 describe('[UI] Load from file', () => {
   let wrapper = null;
 
-  beforeAll(() => {
+  beforeAll(async () => {
     state.setOffline();
     SharedLib.schemaMigration.updateSchema(null, mockData, 'client');
-    state.setLocalState(mockData);
+    await state.setLocalState(mockData);
     const { wrapper: localWrapper } = getPageWrapper();
     wrapper = localWrapper;
     setRoute(`/`);
   });
 
-  it('A user can import data', () => {
+  it('A user can import data', async () => {
     const { wrapper } = getPageWrapper();
     wrapper.find(`#load`).hostNodes().simulate('click');
     wrapper.find(`#theirChoice`).hostNodes().simulate('click');
     SharedLib.schemaMigration.updateSchema(null, mockData, 'client');
-    state.setLocalState(mockData);
+    await state.setLocalState(mockData);
   });
 });

--- a/src/tests/modify-game.test.js
+++ b/src/tests/modify-game.test.js
@@ -28,10 +28,10 @@ describe('[UI] Modify Game (add plate appearances)', () => {
   let wrapper = null;
   let teamId = TEAM_ID;
 
-  beforeAll(() => {
+  beforeAll(async () => {
     state.setOffline();
     SharedLib.schemaMigration.updateSchema(null, mockData, 'client');
-    state.setLocalState(mockData);
+    await state.setLocalState(mockData);
     const { wrapper: localWrapper } = getPageWrapper();
     wrapper = localWrapper;
     setRoute(`/`);

--- a/src/tests/state-index.test.js
+++ b/src/tests/state-index.test.js
@@ -25,10 +25,10 @@ describe('Does the StateIndex class work', () => {
     expect(stateIndex.getGameForPa('2IHrEOVC4hfUTI')).not.toEqual(undefined);
   });
 
-  it('Lookup to deleted Plate Appearance will return undefined', () => {
+  it('Lookup to deleted Plate Appearance will return undefined', async () => {
     const stateObject = mockData;
     SharedLib.schemaMigration.updateSchema(null, stateObject, 'client');
-    state.setLocalState(mockData);
+    await state.setLocalState(mockData);
     const stateIndex = new StateIndex(stateObject);
     const game = stateIndex.getGameForPa('2IHrEOVC4hfUTI');
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6037,6 +6037,11 @@ ignore@^5.2.0:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
   integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
 
+immediate@~3.0.5:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
+  integrity sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==
+
 import-fresh@^3.0.0, import-fresh@^3.1.0, import-fresh@^3.2.1:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"
@@ -7382,6 +7387,13 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+lie@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/lie/-/lie-3.1.1.tgz#9a436b2cc7746ca59de7a41fa469b3efb76bd87e"
+  integrity sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==
+  dependencies:
+    immediate "~3.0.5"
+
 lines-and-columns@^1.1.6:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
@@ -7410,6 +7422,13 @@ loader-utils@^2.0.0:
     big.js "^5.2.2"
     emojis-list "^3.0.0"
     json5 "^2.1.2"
+
+localforage@^1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/localforage/-/localforage-1.10.0.tgz#5c465dc5f62b2807c3a84c0c6a1b1b3212781dd4"
+  integrity sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==
+  dependencies:
+    lie "3.1.1"
 
 locate-path@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
This PR adds the [localforage](https://www.npmjs.com/package/localforage) library, which is a replacement for localStorage that uses indexdb by default, then falls back to localStorage if indexdb is not supported.

Since localForage uses async api, some changes needed to be made to sync, load, and edit actions to wait for the data to be saved before continuing the functions.  Also some tests needed to be fixed.

Running a manual test where I slow my cpu down by 6x shows improvements over the test I ran in https://github.com/thbrown/softball-scorer/pull/95
![image](https://github.com/thbrown/softball-scorer/assets/1266353/276db9d0-5204-4738-add0-e69cc34e88bb)
