### PR TITLE
Add player mapping to Load from File import

### DIFF
--- a/client/src/cards/card-import.tsx
+++ b/client/src/cards/card-import.tsx
@@ -1,117 +1,134 @@
 import React from 'react';
 import dialog from 'dialog';
 import SharedLib from 'shared-lib';
+import type { TopLevelExport, PlateAppearance, PlayerId } from 'shared-lib';
 import { getGlobalState } from 'state';
 import Card from 'elements/card';
 import CardSection from 'elements/card-section';
 import { setRoute } from 'actions/route';
+import PlayerMapping from 'components/player-mapping';
 
 const TLSchemas = SharedLib.schemaValidation.TLSchemas;
+
+type Runners = NonNullable<PlateAppearance['runners']>;
+
+function applyPlayerMapping(
+  data: TopLevelExport,
+  mapping: Record<string, string>
+): TopLevelExport {
+  const replaceId = (id: string): PlayerId => (mapping[id] ?? id) as PlayerId;
+
+  data.players = data.players.filter((p) => !mapping[p.id]);
+
+  for (const team of data.teams) {
+    for (const game of team.games) {
+      game.lineup = game.lineup.map(replaceId);
+      for (const pa of game.plateAppearances) {
+        pa.playerId = replaceId(pa.playerId);
+        remapRunners(pa, replaceId);
+      }
+    }
+  }
+  return data;
+}
+
+function remapRunners(pa: PlateAppearance, replaceId: (id: string) => string): void {
+  if (!pa.runners) return;
+  const runners: Runners = pa.runners;
+  for (const base of ['1B', '2B', '3B'] as const) {
+    if (runners[base]) runners[base] = replaceId(runners[base]!);
+  }
+  if (runners.scored) runners.scored = runners.scored.map(replaceId);
+  if (runners.out) runners.out = runners.out.map(replaceId) as Runners['out'];
+}
 
 const CardImport = () => {
   const [fileName, setFileName] = React.useState<string | null>(null);
   const [loadType, setLoadType] = React.useState('mine');
   const fileInputRef = React.useRef<HTMLInputElement>(null);
+  const [parsedData, setParsedData] = React.useState<TopLevelExport | null>(null);
+  const [playerMapping, setPlayerMapping] = React.useState<Record<string, string | null>>({});
+
+  const localPlayers = getGlobalState().getAllPlayersAlphabetically();
+
   const handleFileInputChange = (ev: React.ChangeEvent<HTMLInputElement>) => {
     const file = ev.target.files?.[0];
-    if (file) setFileName(file.name);
+    if (!file) return;
+    setFileName(file.name);
+    setParsedData(null);
+    setPlayerMapping({});
+    const reader = new FileReader();
+    reader.onload = function (e) {
+      let parsed: TopLevelExport;
+      try {
+        parsed = JSON.parse(e.target?.result as string) as TopLevelExport;
+        const result = SharedLib.schemaMigration.updateSchema(null, parsed, 'export');
+        if (result === 'ERROR') throw new Error('Invalid file format');
+        SharedLib.schemaValidation.validateSchema(parsed, TLSchemas.EXPORT);
+      } catch (exception) {
+        dialog.show_notification(
+          'There was an error while parsing file input: ' + (exception as Error).message
+        );
+        console.error(exception);
+        return;
+      }
+      const localIds = new Set(getGlobalState().getAllPlayers().map((p) => p.id));
+      const initialMapping: Record<string, string | null> = {};
+      for (const p of parsed.players) {
+        if (!localIds.has(p.id)) initialMapping[p.id] = null;
+      }
+      setParsedData(parsed);
+      setPlayerMapping(initialMapping);
+    };
+    reader.readAsText(file);
   };
+
   const handleRadioClick = (ev: React.ChangeEvent<HTMLInputElement>) => {
     setLoadType(ev.target.value);
   };
+
   const handleLoadClick = () => {
-    const file = fileInputRef.current?.files?.[0];
-    if (file) {
-      const reader = new FileReader();
-      reader.onload = function (e) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        let parsedData: any;
-        try {
-          parsedData = JSON.parse(e.target?.result as string);
-
-          // Update the schema
-          let result = SharedLib.schemaMigration.updateSchema(
-            null,
-            parsedData,
-            'export'
-          );
-
-          if (result === 'ERROR') {
-            throw new Error(`Invalid file format`);
-          }
-
-          // Now validate the schema
-          SharedLib.schemaValidation.validateSchema(
-            parsedData,
-            TLSchemas.EXPORT
-          );
-        } catch (exception) {
-          dialog.show_notification(
-            'There was an error while parsing file input: ' + (exception as Error).message
-          );
-          console.error(exception);
-          return;
-        }
-
-        if (loadType === 'mine') {
-          const patchToLocal = SharedLib.objectMerge.diff(
-            parsedData,
-            getGlobalState().getLocalState()
-          );
-          let copy = JSON.parse(JSON.stringify(parsedData));
-          let patched = SharedLib.objectMerge.patch(
-            copy,
-            patchToLocal,
-            true,
-            true
-          );
-
-          getGlobalState().setLocalState(patched);
-        } else if (loadType === 'theirs') {
-          const localToPatch = SharedLib.objectMerge.diff(
-            getGlobalState().getLocalState(),
-            parsedData
-          );
-          let copy = JSON.parse(
-            JSON.stringify(getGlobalState().getLocalState())
-          );
-          let patched = SharedLib.objectMerge.patch(
-            copy,
-            localToPatch,
-            true,
-            true
-          );
-
-          // Changes in the patch win, so we need changes this from "export" to "client" manually
-          patched.metadata.scope = 'client';
-
-          getGlobalState().setLocalState(patched);
-        } else {
-          dialog.show_notification(
-            'Please select load type option before clicking "Load".'
-          );
-          return;
-        }
-        dialog.show_notification(
-          'Your data has successfully been merged with the existing data.'
-        );
-        setRoute('/teams');
-      };
-      reader.readAsText(file);
+    if (!parsedData) {
+      dialog.show_notification('Please select a file first.');
+      return;
     }
+
+    const activeMapping: Record<string, string> = {};
+    for (const [importId, localId] of Object.entries(playerMapping)) {
+      if (localId) activeMapping[importId] = localId;
+    }
+
+    const data = applyPlayerMapping(
+      JSON.parse(JSON.stringify(parsedData)) as TopLevelExport,
+      activeMapping
+    );
+
+    if (loadType === 'mine') {
+      const patchToLocal = SharedLib.objectMerge.diff(data, getGlobalState().getLocalState());
+      const copy = JSON.parse(JSON.stringify(data)) as TopLevelExport;
+      const patched = SharedLib.objectMerge.patch(copy, patchToLocal, true, true);
+      getGlobalState().setLocalState(patched);
+    } else if (loadType === 'theirs') {
+      const localToPatch = SharedLib.objectMerge.diff(getGlobalState().getLocalState(), data);
+      const copy = JSON.parse(JSON.stringify(getGlobalState().getLocalState()));
+      const patched = SharedLib.objectMerge.patch(copy, localToPatch, true, true);
+      patched.metadata.scope = 'client';
+      getGlobalState().setLocalState(patched);
+    } else {
+      dialog.show_notification('Please select load type option before clicking "Load".');
+      return;
+    }
+    dialog.show_notification('Your data has successfully been merged with the existing data.');
+    setRoute('/teams');
   };
+
   return (
     <Card title="Load from File">
       <CardSection isCentered={true}>
         <div style={{ maxWidth: '500px' }}>
           <div>
             <b>
-              <div
-                style={{
-                  textAlign: 'left',
-                  margin: '0px 16px',
-                }}
-              >
+              <div style={{ textAlign: 'left', margin: '0px 16px' }}>
                 Import data data that&apos;s been downloaded from{' '}
                 <span
                   style={{
@@ -121,12 +138,11 @@ const CardImport = () => {
                 >
                   Softball.app&apos;s
                 </span>{' '}
-                export feature. Any data imported here will be merged with your
-                existing data.
+                export feature. Any data imported here will be merged with your existing data.
               </div>
             </b>
           </div>
-          <br></br>
+          <br />
           <div className="import-file-input-container">
             <input
               className="import-file-input"
@@ -136,15 +152,22 @@ const CardImport = () => {
               id="fileData"
               onChange={handleFileInputChange}
             />
-            <label
-              htmlFor="fileData"
-              className="button import-file-input-button"
-            >
+            <label htmlFor="fileData" className="button import-file-input-button">
               {fileName
                 ? fileName
                 : 'First, tap to choose a file or click-and-drag one here.'}
             </label>
           </div>
+
+          {parsedData && (
+            <PlayerMapping
+              importData={parsedData}
+              localPlayers={localPlayers}
+              mapping={playerMapping}
+              onMappingChange={setPlayerMapping}
+            />
+          )}
+
           <div>Next, select what happens in case of a merge conflict:</div>
           <div className="import-radio-buttons-container">
             <div className="radio-button-option">

--- a/client/src/components/player-mapping.tsx
+++ b/client/src/components/player-mapping.tsx
@@ -1,0 +1,174 @@
+import React from 'react';
+import Select from 'react-select';
+import type { Player, TopLevelExport } from 'shared-lib';
+
+interface PlayerMappingProps {
+  importData: TopLevelExport;
+  localPlayers: Player[];
+  mapping: Record<string, string | null>;
+  onMappingChange: (mapping: Record<string, string | null>) => void;
+}
+
+interface PlayerOption {
+  value: string;
+  label: string;
+}
+
+const KEEP_AS_NEW: PlayerOption = { value: '', label: '-- Keep as new player --' };
+
+function levenshtein(a: string, b: string): number {
+  const m = a.length,
+    n = b.length;
+  const dp: number[] = Array.from({ length: n + 1 }, (_, i) => i);
+  for (let i = 1; i <= m; i++) {
+    let prev = dp[0];
+    dp[0] = i;
+    for (let j = 1; j <= n; j++) {
+      const temp = dp[j];
+      dp[j] = a[i - 1] === b[j - 1] ? prev : 1 + Math.min(prev, dp[j], dp[j - 1]);
+      prev = temp;
+    }
+  }
+  return dp[n];
+}
+
+const PlayerMapping = ({
+  importData,
+  localPlayers,
+  mapping,
+  onMappingChange,
+}: PlayerMappingProps) => {
+  const [expanded, setExpanded] = React.useState(false);
+
+  const localIds = React.useMemo(
+    () => new Set(localPlayers.map((p) => p.id)),
+    [localPlayers]
+  );
+
+  const unrecognized = React.useMemo(
+    () => importData.players.filter((p) => !localIds.has(p.id)),
+    [importData.players, localIds]
+  );
+
+  const options: PlayerOption[] = React.useMemo(
+    () => [KEEP_AS_NEW, ...localPlayers.map((p) => ({ value: p.id, label: `${p.name} (${p.gender})` }))],
+    [localPlayers]
+  );
+
+  if (unrecognized.length === 0) return null;
+
+  const mappedCount = Object.values(mapping).filter(Boolean).length;
+
+  const handleAutoMap = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    const newMapping: Record<string, string | null> = { ...mapping };
+    for (const imp of unrecognized) {
+      let bestId: string | null = null;
+      let bestDist = Infinity;
+      for (const local of localPlayers) {
+        const dist = levenshtein(imp.name.toLowerCase(), local.name.toLowerCase());
+        if (dist < bestDist) {
+          bestDist = dist;
+          bestId = local.id;
+        }
+      }
+      newMapping[imp.id] = bestId;
+    }
+    onMappingChange(newMapping);
+  };
+
+  const handleSelectChange = (importId: string, option: PlayerOption | null) => {
+    onMappingChange({ ...mapping, [importId]: option?.value || null });
+  };
+
+  return (
+    <div
+      style={{
+        border: '1px solid var(--color-primary-dark)',
+        borderRadius: '6px',
+        margin: '12px 0',
+        overflow: 'hidden',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          padding: '10px 14px',
+          cursor: 'pointer',
+          background: 'var(--color-background-secondary, #f5f5f5)',
+          minHeight: '44px',
+        }}
+        onClick={() => setExpanded((v) => !v)}
+      >
+        <span style={{ fontWeight: 'bold' }}>
+          {expanded ? '▼' : '▶'} Player Mapping{' '}
+          <span
+            style={{
+              fontWeight: 'normal',
+              fontSize: '0.88em',
+              color: 'var(--color-primary-dark)',
+            }}
+          >
+            ({unrecognized.length} unrecognized
+            {mappedCount > 0 ? `, ${mappedCount} mapped` : ''})
+          </span>
+        </span>
+        {/* Always reserve space for the button to keep the header height stable */}
+        <div
+          className="button primary-button"
+          style={{
+            padding: '4px 12px',
+            fontSize: '0.85em',
+            visibility: expanded ? 'visible' : 'hidden',
+          }}
+          onClick={handleAutoMap}
+        >
+          Auto-map
+        </div>
+      </div>
+
+      {expanded && (
+        <div style={{ padding: '8px 14px 12px' }}>
+          <div style={{ fontSize: '0.82em', color: '#666', marginBottom: '8px' }}>
+            Map each unrecognized player to an existing player, or leave as &quot;Keep as new
+            player&quot;. Mapped players will not be duplicated.
+          </div>
+          {unrecognized.map((imp) => (
+            <div
+              key={imp.id}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: '10px',
+                marginBottom: '8px',
+              }}
+            >
+              <span style={{ flex: '0 0 auto', minWidth: '140px', fontSize: '0.9em' }}>
+                {imp.name}
+                <span style={{ color: '#888', marginLeft: '4px' }}>({imp.gender})</span>
+              </span>
+              <span style={{ color: '#aaa' }}>→</span>
+              <div style={{ flex: 1 }}>
+                <Select
+                  options={options}
+                  value={options.find((o) => o.value === (mapping[imp.id] ?? '')) ?? KEEP_AS_NEW}
+                  onChange={(opt) => handleSelectChange(imp.id, opt)}
+                  isSearchable
+                  menuPortalTarget={document.body}
+                  styles={{
+                    menuPortal: (base) => ({ ...base, zIndex: 9999 }),
+                    control: (base) => ({ ...base, minHeight: '32px' }),
+                  }}
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default PlayerMapping;

--- a/server/src/logger.ts
+++ b/server/src/logger.ts
@@ -26,7 +26,7 @@ const LOG_FORMAT = (): 'json' | 'text' => {
   const cfg = getConfig().logging as any;
   if (cfg && cfg.format === 'json') return 'json';
   if (cfg && cfg.format === 'text') return 'text';
-  return process.stdout.isTTY ? 'text' : 'json';
+  return (process.stdout.isTTY || process.env.DEVELOPMENT === 'true') ? 'text' : 'json';
 };
 
 let logFile: fs.WriteStream | null = null;


### PR DESCRIPTION
## Summary

- Adds a collapsible **Player Mapping** section to the Load from File import screen, shown only when the import file contains players not found in the local account
- Update import card UI

<img width="1244" height="1564" alt="image" src="https://github.com/user-attachments/assets/615e4b56-a421-4713-80f1-d628ed31dd48" />
